### PR TITLE
Fix: Consistently return object with error property

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,20 @@
+{
+  "projectName": "firebase-rules-testing",
+  "projectOwner": "janvogt",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributors": [
+    {
+      "login": "mediavrog",
+      "name": "Maik Buchmeyer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/160785?v=3",
+      "profile": "http://www.mediavrog.net",
+      "contributions": [
+        "code",
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -49,4 +49,15 @@ We use it in production for a small start-up app. It woks for us, but can be cer
 - althoug it's quite fast (thanks modern JS engines), there are a lots of oportunities for performance improvements.
 - your idea?
 
+## Contributors
+
+Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+| [<img src="https://avatars.githubusercontent.com/u/160785?v=3" width="100px;"/><br /><sub>Maik Buchmeyer</sub>](http://www.mediavrog.net/)<br />[💻](https://github.com/janvogt/firebase-rules-testing/commits?author=mediavrog)|
+| :---: |
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.
+Contributions of any kind are welcome!
 

--- a/index.js
+++ b/index.js
@@ -308,16 +308,17 @@ class FirebaseRulesTest {
                     this.state.details.read = rs.filter(o => this.state.allowed == o.result)
                 }
             }
-            this.results.push(`ERROR: Expected ${this.state.method} to be ${verb}. ${msg}\n${JSON.stringify(this.state, null, 2)}`)
+            const errorMessage = `ERROR: Expected ${this.state.method} to be ${verb}. ${msg}`;
+            this.results.push(Object.assign({error: true, errorMessage}, this.state))
         } else {
-            this.results.push(true)
+            this.results.push({error: false})
         }
         this.state = null
         return this
     }
 
     stats () {
-        const successCount = this.results.filter(s => s === true).length
+        const successCount = this.results.filter(s => s.error === false).length
         if (successCount < this.results.length) {
             this.results.filter(s => typeof s === 'string').forEach(stat => {
                 console.log(`${stat}\n`)


### PR DESCRIPTION
Just a small fix to always return an object from the results.

Note: PR should be squash-merged. Sorry didn't rebase